### PR TITLE
Fix bigscreen and hide gray names

### DIFF
--- a/src/data/elements.js
+++ b/src/data/elements.js
@@ -211,6 +211,9 @@ const Elements = {
         selector: `[class^="chat-message-default_endorsement__"]`,
         class: `chat-message-default_endorsement__n_LUu`,
       },
+      grayName: {
+        selector: `.chat-message-default_free___3d5O`,
+      },
       sender: {
         selector: `[class^="chat-message-default_user"]`,
         class: `chat-message-default_user__uVNvH`,

--- a/src/main.js
+++ b/src/main.js
@@ -74,7 +74,7 @@ import "./styles/styles.scss";
         state.get("isShowLive") || hasFetchedShowLiveStatus;
       if (!liveStatusFetched) {
         hasFetchedShowLiveStatus = true;
-        isShowLive = getShowLiveStatus();
+        isShowLive = await getShowLiveStatus();
         state.set("isShowLive", isShowLive);
       }
     }

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -39,6 +39,7 @@ const Config = () => {
     hideSFXMessages: false,
     hideSystem: false,
     hideFonts: false,
+    hideGrayNames: false,
 
     enableImprovedTagging: true,
 
@@ -67,16 +68,6 @@ const Config = () => {
 
     friends: [],
     watching: [],
-    // friendsColor: {
-    //   background: "rgba(0, 149, 255, 0.1)",
-    //   outline: "rgba(0, 149, 255, 0.25)",
-    //   font: "rgb(255,255,255)",
-    // },
-    // watchingColor: {
-    //   background: "rgba(0, 255, 4, 0.1)",
-    //   outline: "rgba(0, 255, 4, 0.25)",
-    //   font: "rgb(255,255,255)",
-    // },
   };
 
   const pluginObj = {
@@ -456,6 +447,18 @@ const Config = () => {
                 label: "?",
                 text: `<p>Enabling this option hides <strong>Special Chat Fonts</strong>.</p>
                 <p>These are the messages in non-standard font.</p>`,
+              },
+            },
+            // hideGrayNames
+            {
+              name: "hideGrayNames",
+              label: "Hide Gray Names",
+              type: "toggle",
+              value: cfg.hideGrayNames,
+              group: "hiders",
+              help: {
+                label: "?",
+                text: `<p>Enabling this option hides chat messages from <strong>Gray Names (free users)</strong>.</p>`,
               },
             },
 

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -154,18 +154,32 @@ export const toggleScanLines = (toggle) => {
   body.classList.toggle("maejok-hide-scan_lines", toggle);
 };
 
-export const getShowLiveStatus = () => {
-  const status = localStorage.getItem("live-streams-status");
+export const getShowLiveStatus = async () => {
+  const livestreams = await fetchLiveStreamStatus();
   let online = false;
 
-  if (status) {
-    const value = JSON.parse(status).value;
-    online = Object.values(value).some(function (s) {
+  if (livestreams) {
+    online = Object.values(livestreams.status).some(function (s) {
       return s === "online";
     });
   }
 
   return online;
+};
+
+const fetchLiveStreamStatus = async () => {
+  const options = {
+    method: "GET",
+  };
+  try {
+    const data = await fetch(
+      `https://api.fishtank.live/v1/live-streams/status`,
+      options
+    );
+    return await data?.json();
+  } catch (error) {
+    return false;
+  }
 };
 
 export const toggleControlOverlay = () => {

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -529,6 +529,10 @@ export const processChatMessage = (node, logMentions = true) => {
         element: "endorsement",
         hide: cfg.enablePlugin ? cfg.hideEndorsements : false,
       },
+      hideGrayNames: {
+        element: "grayName",
+        hide: cfg.enablePlugin ? cfg.hideGrayNames : false,
+      },
     };
 
     const hideTypes = Object.entries(messageHideMap).reduce(


### PR DESCRIPTION
### Description
- fix bigscreen mode
  - live status check that applied styles was broken.  it was using a cache value that is never actually updated.  fix makes api call to check if any streams are online.
- add config option to hide gray name chat messages  