### PR TITLE
Fix hide video controls

### DIFF
--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -17,7 +17,7 @@ const Config = () => {
     enableControlOverlay: false,
     enableTimestampOverlay: false,
     enableUserOverlay: false,
-    controlOverlayState: false,
+    controlOverlayDisabled: false,
     disableSoundEffects: false,
     hideGlobalMissions: false,
     hideScreenTakeovers: false,
@@ -178,6 +178,7 @@ const Config = () => {
               help: {
                 label: "?",
                 text: `<p>Enabling this option creates a keyboard shortcut to toggle <strong>the video controls overlay</strong> which will show or hide the overlay.</p>
+                <p><strong><i>It will hide the controls when enabled, but you can show them again by using the shortcut.  You may have to click on the window to regain focus for the shortcut to work.</i></strong></p>
                 <p>Keyboard Shortcut: <strong>CTRL+SHIFT+H</strong></p>`,
               },
             },

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -21,6 +21,7 @@ const Config = () => {
     disableSoundEffects: false,
     hideGlobalMissions: false,
     hideScreenTakeovers: false,
+    hideNavigationOverlay: false,
 
     enableUpdateChecks: true,
     updateCheckFrequency: 10,
@@ -189,8 +190,7 @@ const Config = () => {
               group: "site-options",
               help: {
                 label: "?",
-                text: `<p>Enabling this option will display a timestamp of the current time in the tank at the top of the video player.</p>
-                <p><i><strong>Note there may be a delay before it shows up because the function is on an interval and I'm lazy.</strong></i></p>`,
+                text: `<p>Enabling this option will display a timestamp of the current time in the tank at the top of the video player.</p>`,
               },
             },
             // enableUserOverlay
@@ -316,6 +316,18 @@ const Config = () => {
               help: {
                 label: "?",
                 text: `<p>Enabling this option hide the <strong>Scan Line Effect</strong> seen across the site.</p>`,
+              },
+            },
+            // hideNavigationOverlay
+            {
+              name: "hideNavigationOverlay",
+              label: "Hide Stream Navigation Overlay",
+              type: "toggle",
+              value: cfg.hideNavigationOverlay,
+              group: "site-options",
+              help: {
+                label: "?",
+                text: `<p>Enabling this option hide the <strong>Stream Navigation Overlay</strong> that displays semi-transparent polygons over the livestream on hover.</p>`,
               },
             },
           ],

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -182,10 +182,7 @@ const fetchLiveStreamStatus = async () => {
   }
 };
 
-export const toggleControlOverlay = () => {
-  if (!config.get("enableControlOverlay")) {
-    return;
-  }
+export const toggleControlOverlay = (force) => {
   const videoControls = document.querySelector(
     ELEMENTS.livestreams.controls.selector
   );
@@ -193,15 +190,27 @@ export const toggleControlOverlay = () => {
     ELEMENTS.livestreams.quality.selector
   );
 
-  const toggle = config.get("controlOverlayState");
-  config.set("controlOverlayState", !toggle);
+  if (force !== undefined) {
+    state.set("controlOverlayDisabled", force);
+  }
 
-  if (toggle) {
-    videoControls.style.display = "none";
-    qualityControl.style.display = "none";
+  if (!videoControls || !qualityControl) {
+    return;
+  }
+
+  let disabled = !force;
+
+  if (force === undefined) {
+    disabled = state.get("controlOverlayDisabled");
+    state.set("controlOverlayDisabled", !disabled);
+  }
+
+  if (disabled) {
+    videoControls.classList.remove("maejok-hide");
+    qualityControl.classList.remove("maejok-hide");
   } else {
-    videoControls.style.display = "";
-    qualityControl.style.display = "";
+    videoControls.classList.add("maejok-hide");
+    qualityControl.classList.add("maejok-hide");
   }
 };
 

--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -268,7 +268,15 @@ export const displayCurrentTankTime = () => {
 };
 
 export const toggleUserOverlay = (toggle) => {
+  const userOverlay = document.querySelector(
+    ELEMENTS.livestreams.overlay.selector
+  );
+
   if (toggle) {
+    if (userOverlay) {
+      return;
+    }
+
     const { userOverlayHTML } = state.get("user");
     if (!userOverlayHTML) {
       const displayNameElement = document.querySelector(
@@ -280,10 +288,6 @@ export const toggleUserOverlay = (toggle) => {
 
     displayUserNameOverlay();
   } else {
-    const userOverlay = document.querySelector(
-      ELEMENTS.livestreams.overlay.selector
-    );
-
     userOverlay?.remove();
   }
 };
@@ -346,6 +350,22 @@ export const toggleDimMode = (toggle) => {
   } else {
     const styles = document.getElementById("maejok-darkmode");
     styles?.remove();
+  }
+};
+
+export const toggleNavigationOverlay = (toggle) => {
+  const zoneOverlay = document.querySelector(
+    ".clickable-zones_clickable-zones__OgYjT"
+  );
+
+  if (!zoneOverlay) {
+    return;
+  }
+
+  if (toggle) {
+    zoneOverlay.style.display = "none";
+  } else {
+    zoneOverlay.style.display = "";
   }
 };
 

--- a/src/modules/observers.js
+++ b/src/modules/observers.js
@@ -6,6 +6,7 @@ import {
   checkTTSFilteredWords,
   displayCurrentTankTime,
   displayUserNameOverlay,
+  toggleNavigationOverlay,
 } from "./functions";
 import ELEMENTS from "../data/elements";
 import { makeDraggable } from "./events";
@@ -185,6 +186,10 @@ const observers = {
 
             if (config.get("enableUserOverlay")) {
               displayUserNameOverlay();
+            }
+
+            if (config.get("hideNavigationOverlay")) {
+              toggleNavigationOverlay(true);
             }
           });
         });

--- a/src/modules/observers.js
+++ b/src/modules/observers.js
@@ -7,6 +7,7 @@ import {
   displayCurrentTankTime,
   displayUserNameOverlay,
   toggleNavigationOverlay,
+  toggleControlOverlay,
 } from "./functions";
 import ELEMENTS from "../data/elements";
 import { makeDraggable } from "./events";
@@ -156,40 +157,63 @@ const observers = {
         mutations.forEach((mutation) => {
           if (
             mutation.type !== "childList" ||
-            mutation.addedNodes.length === 0 ||
-            !mutation.addedNodes[0].classList?.contains(
-              ELEMENTS.livestreams.player.class
-            )
+            mutation.addedNodes.length === 0
           ) {
             return;
           }
 
+          const livestreamAdded = mutation.addedNodes[0].classList?.contains(
+            ELEMENTS.livestreams.player.class
+          );
+
+          const playerControlsAdded =
+            mutation.addedNodes[0].classList?.contains(
+              "livepeer-video-player_controls__y36El"
+            );
+
+          if (!livestreamAdded && !playerControlsAdded) {
+            return;
+          }
+
+          const controlOverlayEnabled = config.get("enableControlOverlay");
+          const timestampOverlayEnabled = config.get("enableTimestampOverlay");
+          const userOverlayEnabled = config.get("enableUserOverlay");
+
           if (
-            !config.get("enableTimestampOverlay") &&
-            !config.get("enableUserOverlay")
+            !controlOverlayEnabled &&
+            !timestampOverlayEnabled &&
+            !userOverlayEnabled
           ) {
             return;
           }
 
           mutation.addedNodes.forEach((addedNode) => {
-            const liveStreamPanel = document.querySelector(
-              ELEMENTS.livestreams.selected.selector
-            );
+            if (livestreamAdded) {
+              const liveStreamPanel = document.querySelector(
+                ELEMENTS.livestreams.selected.selector
+              );
 
-            if (!liveStreamPanel) {
-              return;
+              if (!liveStreamPanel) {
+                return;
+              }
+
+              if (config.get("enableTimestampOverlay")) {
+                displayCurrentTankTime();
+              }
+
+              if (config.get("enableUserOverlay")) {
+                displayUserNameOverlay();
+              }
+
+              if (config.get("hideNavigationOverlay")) {
+                toggleNavigationOverlay(true);
+              }
             }
 
-            if (config.get("enableTimestampOverlay")) {
-              displayCurrentTankTime();
-            }
-
-            if (config.get("enableUserOverlay")) {
-              displayUserNameOverlay();
-            }
-
-            if (config.get("hideNavigationOverlay")) {
-              toggleNavigationOverlay(true);
+            if (playerControlsAdded) {
+              if (config.get("enableControlOverlay")) {
+                toggleControlOverlay(state.get("controlOverlayDisabled"));
+              }
             }
           });
         });

--- a/src/modules/settings.js
+++ b/src/modules/settings.js
@@ -30,6 +30,7 @@ import {
   toggleNavigationOverlay,
   toggleUserOverlay,
   keyEventToString,
+  toggleControlOverlay,
 } from "./functions";
 import {
   start as startRecentChatters,
@@ -49,6 +50,7 @@ export const saveSettings = async () => {
   const prevHideGlobalMissions = config.get("hideGlobalMissions");
   const prevDragModal = config.get("enableDragModal");
   const prevTTSFilter = config.get("enableTTSFilterWarning");
+  const prevControlOverlay = config.get("enableControlOverlay");
 
   inputs.forEach((input) => {
     const key = input.id.replace("-hidden", "");
@@ -132,6 +134,8 @@ export const saveSettings = async () => {
   const ttsFilterJustEnabled =
     config.get("enableTTSFilterWarning") &&
     prevTTSFilter !== config.get("enableTTSFilterWarning");
+  const controlOverlayJustChanged =
+    prevControlOverlay !== config.get("enableControlOverlay");
 
   if (
     hideGlobalMissionsJustEnabled ||
@@ -140,6 +144,10 @@ export const saveSettings = async () => {
   ) {
     observers.body.start();
     observers.modal.start();
+  }
+
+  if (controlOverlayJustChanged) {
+    toggleControlOverlay(config.get("enableControlOverlay"));
   }
 
   scrollToBottom();

--- a/src/modules/settings.js
+++ b/src/modules/settings.js
@@ -27,6 +27,7 @@ import {
   toggleScanLines,
   toggleScreenTakeovers,
   toggleTimestampOverlay,
+  toggleNavigationOverlay,
   toggleUserOverlay,
   keyEventToString,
 } from "./functions";
@@ -73,6 +74,7 @@ export const saveSettings = async () => {
   toggleScanLines();
   toggleDimMode(config.get("enableDimMode"));
   toggleTimestampOverlay(config.get("enableTimestampOverlay"));
+  toggleNavigationOverlay(config.get("hideNavigationOverlay"));
   toggleUserOverlay(config.get("enableUserOverlay"));
   toggleScreenTakeovers(config.get("hideScreenTakeovers"));
 

--- a/src/modules/state.js
+++ b/src/modules/state.js
@@ -6,6 +6,7 @@ const State = () => {
     modals: [],
     user: null,
     bigScreenState: false,
+    controlOverlayDisabled: false,
     mentions: [],
     recentChatters: [],
     observers: {

--- a/src/styles/components/_misc.scss
+++ b/src/styles/components/_misc.scss
@@ -94,7 +94,7 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 4px;
+  padding: 2px;
   background-color: rgba(0, 0, 0, .5);
   position: absolute;
   left: 50%;
@@ -102,6 +102,7 @@
   color: #00FF00; /* Adjust color as needed */
   text-align: center;
   white-space: nowrap;
+  line-height: 12px;
 }
 
 .maejok-timestamp-day {


### PR DESCRIPTION
### Description
Improve the video control overlay hide shortcut
- automatically hide controls when enabled
- fixed issue where sometimes you had to use the shortcut twice for it to work (i think)
- fix issue where switching cams would cause the overlay to show up again