### PR TITLE
Fix switch to room by polygon not working

### DIFF
--- a/src/modules/functions.js
+++ b/src/modules/functions.js
@@ -728,7 +728,6 @@ const switchToRoom = async (stream) => {
               new MouseEvent("click", {
                 bubbles: true,
                 cancelable: true,
-                view: window,
               })
             );
             return;


### PR DESCRIPTION
For some reason switching via polygons worked in dev but not build. Removing the view fixed it, tested with dev extension and the prod build (`npm run build`)