### PR TITLE
add TTS, SFX, and fishtoy buttons in theater mode

### DIFF
--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -30,6 +30,7 @@ const Config = () => {
     enableCameraNameOverlay: false,
     enableTTSHistoryOverlay: false,
     enableHideChatButton: false,
+    enableActionButtons: true,
     enableUserOverlay: false,
     enableStreamSearch: false,
     controlOverlayDisabled: false,
@@ -600,6 +601,18 @@ const Config = () => {
               help: {
                 label: "?",
                 text: `<p><strong>Enabling this option will display a hide chat button at the top of chat when in theater mode.</strong></p>`,
+              },
+            },
+            // enableActionButtons
+            {
+              name: "enableActionButtons",
+              label: "Enable TTS/SFX/Fishtoy buttons",
+              type: "toggle",
+              value: cfg.enableActionButtons,
+              group: "theater-mode-options",
+              help: {
+                label: "?",
+                text: `<p><strong>Enabling this option will display the TTS, SFX, and Fishtoy buttons at the bottom right when in theater mode.</strong></p>`,
               },
             },
           ],


### PR DESCRIPTION
Add support for displaying the TTS, SFX, and fishtoy button when in theater mode and chat is hidden. Configurable setting, defaults to true. Not sure how important zindex is.

I noticed the toggle hide chat button does not disappear when chat is hidden and theater mode is exited.